### PR TITLE
Example collector tweaks

### DIFF
--- a/otel/0.8/otel_guaranteed_working.yaml
+++ b/otel/0.8/otel_guaranteed_working.yaml
@@ -77,7 +77,8 @@ spec:
             - 'IsMatch(attributes["mdai_service"], "${env:SERVICE_LIST_REGEX}")'
 
     exporters:
-      debug: { }
+      debug/received: { }
+      debug/exported: { }
       otlp/observer:
         endpoint: mdaihub-sample-observer-collector-service.mdai.svc.cluster.local:4317
         tls:
@@ -102,9 +103,9 @@ spec:
         logs/customer_pipeline:
           receivers: [ otlp, fluentforward ]
           processors: [ filter/service_list, memory_limiter, batch, groupbyattrs, resource/observer_exporter_tag ]
-          exporters: [ debug, otlp/observer ]
+          exporters: [ debug/received, otlp/observer ]
 
         logs/watch_receivers:
           receivers: [ otlp, fluentforward ]
           processors: [ memory_limiter, batch, groupbyattrs, resource/observer_receiver_tag ]
-          exporters: [ debug, otlp/observer ]
+          exporters: [ debug/exported, otlp/observer ]

--- a/otel/0.8/otel_guaranteed_working.yaml
+++ b/otel/0.8/otel_guaranteed_working.yaml
@@ -103,9 +103,9 @@ spec:
         logs/customer_pipeline:
           receivers: [ otlp, fluentforward ]
           processors: [ filter/service_list, memory_limiter, batch, groupbyattrs, resource/observer_exporter_tag ]
-          exporters: [ debug/received, otlp/observer ]
+          exporters: [ debug/exported, otlp/observer ]
 
         logs/watch_receivers:
           receivers: [ otlp, fluentforward ]
           processors: [ memory_limiter, batch, groupbyattrs, resource/observer_receiver_tag ]
-          exporters: [ debug/exported, otlp/observer ]
+          exporters: [ debug/received, otlp/observer ]

--- a/otel/0.8/otel_guaranteed_working.yaml
+++ b/otel/0.8/otel_guaranteed_working.yaml
@@ -74,7 +74,7 @@ spec:
         error_mode: ignore
         logs:
           log_record:
-            - 'IsMatch(attributes["mdai_service"], "${env:SERVICE_LIST_REGEX}")'
+            - '"${env:SERVICE_LIST_REGEX}" != "" and IsMatch(attributes["mdai_service"], "${env:SERVICE_LIST_REGEX}")'
 
     exporters:
       debug/received: { }


### PR DESCRIPTION
- Separate received/exported debug exporters for better visibility
- Add additional filter condition so data doesn't get filtered if nothing is in the service list