### PR TITLE
Update otel_ref.yaml

### DIFF
--- a/otel/otel_ref.yaml
+++ b/otel/otel_ref.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   managementState: managed
   image: otel/opentelemetry-collector-contrib:0.118.0
-  replicas: 5
+  replicas: 1
   resources:
     limits:
       memory: "256Mi"


### PR DESCRIPTION
If this really has to be 5 for some reason, ignore this pr. I think originally for the filter demo we had 1.