### PR TITLE
feat: asalehi noisy neighbor lab sample PR

### DIFF
--- a/0.9.0/use_cases/noisy_neighbor/Makefile
+++ b/0.9.0/use_cases/noisy_neighbor/Makefile
@@ -1,0 +1,21 @@
+CLUSTER ?= mdai-labs
+IMAGE   ?= noisy-app:0.2.0
+
+.PHONY: build load apply run teardown logs
+
+build:
+	docker build -t $(IMAGE) ./app
+
+load: build
+	kind load docker-image $(IMAGE) --name $(CLUSTER)
+
+apply:
+	./scripts/run-scenario.sh
+
+run: load apply
+
+teardown:
+	./scripts/teardown.sh
+
+logs:
+	kubectl -n noisy-neighbor logs -f deploy/loadgen

--- a/0.9.0/use_cases/noisy_neighbor/README.md
+++ b/0.9.0/use_cases/noisy_neighbor/README.md
@@ -1,0 +1,232 @@
+# Noisy-Neighbor Lab — closed-loop throttle + diagnostic tail sampling
+
+A single noisy tenant is about to topple a shared Postgres. MDAI detects the condition from a *combination* of database-pressure metrics and application-level per-tenant metrics, then makes **two simultaneous changes**:
+
+1. **Hard corrective** *(sub-second)* — the app middleware caps the noisy tenant at 5 RPS via a `callWebhook` push.
+2. **Diagnostic tuning** *(~ConfigMap-refresh, ~60s)* — the OTel tail sampler reconfigures itself: it now keeps **100% of the noisy tenant's genuine DB errors**, **50% of its normal traffic**, drops healthy tenants to **2% sampling**, and — the payoff — **deliberately drops 99% of the 429s MDAI itself just caused** (keeping a 1% sanity sample). Telemetry about your own mitigation isn't worth paying to store.
+
+When the pressure clears, **both changes reverse automatically**.
+
+> The story is "we kept more of the bad-behavior traces precisely when we needed them, stopped paying to store the throttle-rejections we deliberately caused, and threw the brakes on the offender — all from one declarative rule. **Sampling tuned by intent, not just by volume.**"
+
+## Architecture
+
+```
+                                  load-gen
+                                     │  rps mix: noisy-1=50, others=5
+                                     ▼
+                              ┌──────────────────────────────┐
+                  HTTP +      │  noisy-app  (FastAPI)        │
+                  X-Tenant-ID │   ├ token-bucket middleware  │
+                              │   ├ injects 10% 503 (sim'd   │
+                              │   │  DB timeouts)            │
+                              │   └ OTel SDK → adds tenant   │
+                              │     attr to every span       │
+                              └────┬──────────────┬──────────┘
+                                   │ SQL          │ OTLP/gRPC
+                                   ▼              ▼
+                       ┌────────────────┐   ┌──────────────────┐
+                       │  postgres +    │   │ trace-balancer   │
+                       │  exporter      │   │ (load-balances   │
+                       │  max_conns=100 │   │  spans by trace) │
+                       └────────┬───────┘   └────────┬─────────┘
+                                │ scrape             │ OTLP/gRPC
+                                ▼                    ▼
+                     ┌─────────────────────────────────────────┐
+                     │             Prometheus                  │
+                     └───────────────────┬─────────────────────┘
+                                         │ alerts
+                                         ▼
+                               ┌─────────────────┐
+                               │  MdaiHub CR     │
+                               │  Event Handler  │
+                               └────┬──────┬─────┘
+                                    │      │
+              ┌─────────────────────┘      └───────────────────────┐
+              ▼                                                    ▼
+   ┌─────────────────────────┐                       ┌──────────────────────────┐
+   │ Valkey (variable store) │                       │ HTTP POST                │
+   │  rate_limited_tenants   │                       │  /admin/rate-limits      │
+   │  noisy_tenant_list      │                       │   tenant=noisy-1 rps=5   │
+   │  healthy_tenant_list    │                       │                          │
+   └───────────┬─────────────┘                       └──────────────┬───────────┘
+               │ ConfigMap mount                                    │
+               │ (~60s kubelet refresh)                             │ token-bucket
+               ▼                                                    ▼
+   ┌─────────────────────────┐                       (back to noisy-app middleware
+   │  gateway-collector      │                         in the top of the diagram)
+   │  envFrom variables CM   │
+   │   ├ NOISY_TENANT_LIST   │
+   │   └ HEALTHY_TENANT_LIST │
+   │                         │
+   │  tail_sampling          │
+   │   pol 0: noisy+429 drop │  →   1%   (first match wins)
+   │   pol 1: noisy+ERROR    │  → 100%
+   │   pol 2: noisy+normal   │  →  50%
+   │   pol 3: healthy        │  →   2%
+   │   pol 4: default        │  →  10%
+   └──────────┬──────────────┘
+              │
+              ▼
+       (vendor / store)
+```
+
+## The control loop, end to end
+
+1. **Postgres exporter** ships `pg_stat_database_*`, `pg_stat_activity_count`, `pg_settings_max_connections`.
+2. **noisy-app** ships `db_connections_per_tenant{tenant=…}` from per-tenant asyncpg pools, plus traces with a `tenant` span attribute.
+3. **`db_pressure` alert** fires when cache hit ratio drops below 0.7 OR connection saturation exceeds 20% (lab-tuned threshold — see *Tunables*). This workload is **connection-bound** — each `/work` request holds a pooled connection across `pg_sleep` calls — so in practice the connection-saturation leg is what fires; the cache-hit leg is a generic template that won't move here (the app does no buffer-read I/O). The "DB failure" story on the dashboard is carried by the injected 5xx errors, not the cache-hit metric.
+4. **`noisy_neighbor_detected` alert** fires only when *both* `db_pressure` is firing AND one tenant holds >50% of *active* connections.
+5. The matching rule does **four** things atomically:
+   - `addToMap` into `rate_limited_tenants` (Valkey state).
+   - `callWebhook` → POST to `noisy-app:8080/admin/rate-limits` → middleware caps the tenant at 5 RPS *immediately*.
+   - `addToSet` into `noisy_tenant_list`.
+   - `removeFromSet` from `healthy_tenant_list`.
+6. The `mdai-operator` materializes the two sets into env vars (`NOISY_TENANT_LIST`, `HEALTHY_TENANT_LIST`) inside the `mdaihub-noisy-neighbor-variables` ConfigMap.
+7. The **gateway collector** mounts that ConfigMap and re-reads it on the kubelet's normal refresh cadence (~60s). The `tail_sampling` processor evaluates **5 policies in order, first match wins**:
+   - **policy 0 `noisy-tenant-throttled-drop`** — a noisy span carrying `throttled==true` (a 429 *we* just caused) is kept at only **1%**. Placed first so it wins over policy 2; the other 99% of redundant throttle-rejection traces are dropped.
+   - **policy 1 `noisy-tenant-errors`** — a noisy span with a *genuine* DB error (`error.injected==true`, or `STATUS_CODE_ERROR` that is **not** a throttle) is kept at **100%**.
+   - **policy 2 `noisy-tenant-normal`** — the noisy tenant's remaining successful traffic, kept at **50%** for context.
+   - **policy 3 `healthy-tenant-sample`** — healthy tenants ride **2%**.
+   - **policy 4 `default-sample`** — catch-all (spans with no tenant attr, e.g. infra) at **10%**.
+
+   When the sets swap members, these `string_attribute` policies match different tenants → sampling ratios flip.
+8. When pressure clears (`keep_firing_for: 90s` hysteresis), the resolved-rule fires the inverse: webhook lifts the throttle, sets swap members back.
+
+## What the demo shows
+
+Once `noisy_neighbor_firing` fires:
+
+- **Loadgen output:** `noisy-1` goes from `ok=50/s 429=0 5xx≈5` (steady) to `ok=5/s 429≈45 5xx≈0.5`. Other tenants unaffected.
+- **`/admin/rate-limits`:** `{}` → `{"noisy-1": 5.0}`.
+- **Valkey sets:** `noisy_tenant_list` ← `["noisy-1"]`; `healthy_tenant_list` ← `["tenant-a","tenant-b","tenant-c"]`.
+- **ConfigMap:** `mdaihub-noisy-neighbor-variables` gains `NOISY_TENANT_LIST=noisy-1`, `HEALTHY_TENANT_LIST=tenant-a|tenant-b|tenant-c`.
+- **Tail sampler** (after ~60s), the headline shot — four lines move at once:
+  - `noisy-tenant-errors` jumps up and stays high — we now keep **100% of the noisy tenant's genuine DB failures** (the injected 5xx). It does **not** include 429s — those are handled by policy 0.
+  - `noisy-tenant-normal` rises briefly, then settles at 50% of the noisy tenant's successful traffic.
+  - `healthy-tenant-sample` collapses toward the 2% floor — the rest of the world.
+  - `noisy-tenant-throttled-drop` sits near the **1% floor** — a thin line hugging the bottom, visibly far below the errors policy. **MDAI knows it *caused* those 429s by rate-limiting, so it stops paying to capture its own mitigation.** The 429 *rate* is still fully on the Action-1 metrics panel (`app_throttled_total`) — we just don't keep the redundant per-request traces.
+
+The headline panel in Grafana is `sum by (policy) (rate(otelcol_processor_tail_sampling_count_traces_sampled[1m]))`, log-scaled so every policy line is individually readable — you can literally watch the ratios flip when the rule fires. **Sampling tuned by intent, not just by volume.**
+
+## Design choices and why
+
+- **Option B + `callWebhook`** for the throttle (one Python file does the limiting). Production would more likely use Envoy + a controller pod, but the lab's point is to show *MDAI*, not Envoy. `callWebhook` is push (sub-second), no Redis client in the app.
+- **Tail sampling for the diagnostic side.** Static sampling is the bluntest instrument in the observability stack. MDAI turns it into a closed-loop knob: "sample everything from the suspect, sample less of the boring." The sharpest expression of this is the **`noisy-tenant-throttled-drop` policy (evaluated first)**: once MDAI decides to rate-limit a tenant, the resulting 429s are *its own mitigation working as intended* — no diagnostic value. So it keeps a 1% sanity sample and drops the rest, while still keeping 100% of that tenant's *genuine* DB errors. The sampler is tuned by **intent**, not volume.
+- **Two-collector pattern.** Tail sampling needs all spans of a trace to land on the same collector. The `loadbalancing` exporter routes by `traceID` to the gateway, then the gateway makes the sampling decision once per trace.
+- **Hysteresis via `keep_firing_for: 90s`** on both alerts. Prevents flapping when throttling brings pressure right back under the threshold.
+
+## Postgres-in-kind stand-in (caveat)
+
+The lab uses Postgres-in-kind as a stand-in for what would in production be RDS / Cloud SQL / AlloyDB.
+
+| Real prod metric | Lab proxy | Why |
+|---|---|---|
+| `FreeableMemory` (RDS) | `pg_stat_database` cache hit ratio | Postgres doesn't expose freeable memory; cache hit ratio drops when working set spills to disk. |
+| DB CPU utilization | not used in this lab's expr | `node_cpu_seconds_total` reflects the kind node, not the DB. |
+| `DatabaseConnections` (RDS) | `pg_stat_activity_count` | Direct equivalent. |
+| `max_connections` | `pg_settings_max_connections` | Direct equivalent. |
+
+Swap the alert expressions for managed-DB equivalents from CloudWatch / GCP managed-prometheus when porting.
+
+## Tunables
+
+| Knob | Default | Where |
+|---|---|---|
+| Cache hit ratio threshold | 0.7 | `hub.yaml` → `prometheusAlerts.db_pressure.expr` |
+| Connection saturation threshold | 0.2 | same (tuned for in-kind PG + asyncpg idle-decay; prod-comparable ≈ 0.8) |
+| Dominance threshold | 0.5 | `prometheusAlerts.noisy_neighbor_detected.expr` |
+| Alert detection window | 30s | `for:` |
+| Hysteresis | 90s | `keep_firing_for:` |
+| RPS cap when throttled | 5 | `rules.noisy_neighbor_firing` → `addToMap.value` and `callWebhook.templateValues.rps` |
+| Injected 5xx rate | 10% | `manifests/20-noisy-app.yaml` → `ERROR_INJECT_PROB` |
+| `noisy-tenant-throttled-drop` sampling | 1% | `otel.yaml` → tail_sampling policy 0 (evaluated first) |
+| `noisy-tenant-errors` sampling | 100% | policy 1 |
+| `noisy-tenant-normal` sampling | 50% | policy 2 |
+| `healthy-tenant-sample` sampling | 2% | policy 3 |
+| `default-sample` sampling | 10% | policy 4 |
+| Per-tenant DB pool max | 30 | `manifests/20-noisy-app.yaml` env |
+| Load mix (rps per tenant) | 5/5/5/50 | `manifests/30-loadgen.yaml` ConfigMap |
+
+## Run
+
+Prereq: MDAI base install (`./cli/mdai.sh install -f values/overrides_0.9.0-partial.yaml`).
+
+```sh
+cd 0.9.0/use_cases/noisy_neighbor
+make run          # build image, kind-load, apply everything, SADD healthy_tenant_list, scale loadgen
+make teardown
+```
+
+## What to watch
+
+```sh
+# 1. Loadgen output (status mix per tenant — watch 5xx and 429 rise on noisy-1)
+kubectl -n noisy-neighbor logs -f deploy/loadgen
+
+# 2. Live rate-limit table
+kubectl -n noisy-neighbor port-forward svc/noisy-app 8080:8080 &
+watch -n 1 'curl -s localhost:8080/admin/rate-limits'
+
+# 3. Valkey sets — the variable store, swapping members in real time
+PASS=$(kubectl -n mdai get secret valkey-secret -o jsonpath='{.data.VALKEY_PASSWORD}' | base64 -d)
+watch -n 2 "kubectl -n mdai exec mdai-valkey-primary-0 -- env P=$PASS sh -c \
+  'valkey-cli -a \$P --no-auth-warning SMEMBERS variable/mdaihub-noisy-neighbor/noisy_tenant_list && \
+   echo --- && \
+   valkey-cli -a \$P --no-auth-warning SMEMBERS variable/mdaihub-noisy-neighbor/healthy_tenant_list'"
+
+# 4. Tail-sampler decisions by policy — the headline panel
+kubectl -n mdai port-forward svc/kube-prometheus-stack-prometheus 9090:9090 &
+open 'http://localhost:9090/graph?g0.expr=sum%20by%20(policy)%20(rate(otelcol_processor_tail_sampling_count_traces_sampled%5B1m%5D))&g0.tab=0&g0.range_input=15m'
+
+# 5. Prometheus alerts
+open http://localhost:9090/alerts
+
+# 6. Grafana (admin / mdai)
+kubectl -n mdai port-forward svc/mdai-grafana 3000:80 &
+open http://localhost:3000
+```
+
+Useful PromQL queries for the demo:
+
+| Goal | Query |
+|---|---|
+| **Headline: sampling shift** | `sum by (policy) (rate(otelcol_processor_tail_sampling_count_traces_sampled{sampled="true"}[1m]))` |
+| Sampling kept-vs-dropped per policy | `sum by (policy, sampled) (rate(otelcol_processor_tail_sampling_count_traces_sampled[1m]))` |
+| Connection pressure | `sum(pg_stat_activity_count) / on() group_left() max(pg_settings_max_connections)` |
+| Per-tenant active conns | `db_connections_per_tenant` |
+| Throttled rate | `sum by (tenant) (rate(app_throttled_total[1m]))` |
+| Error rate per tenant | `sum by (tenant) (rate(app_errors_total[1m]))` |
+| Dominance ratio | `max by (tenant) (db_connections_per_tenant) / on() group_left() clamp_min(sum(db_connections_per_tenant), 1)` |
+
+## Limitations
+
+- **In-app limiter is per-pod.** Multi-replica needs a distributed limiter (shared Valkey-backed token bucket, or Envoy + RateLimit Service). Lab uses 1 replica.
+- **No PgBouncer.** Production usually has a pooler in front of the DB.
+- **ConfigMap refresh lag.** Kubelet refreshes mounted ConfigMaps every ~60-90s. Acceptable for the diagnostic side; we don't want it for the corrective side, which is why the throttle goes through `callWebhook` instead.
+- **Tail sampling latency.** `decision_wait: 10s` — spans sit in memory for up to 10s before the sampler picks them up. That's the standard tail-sampling tradeoff and is independent of MDAI.
+
+## File map
+
+```
+noisy_neighbor/
+├── README.md                  (this file)
+├── RECORDED_RUN.md            (evidence from a real run)
+├── Makefile                   (build / load / apply / teardown)
+├── hub.yaml                   (4 vars, 2 alerts, 4 rules — adds set actions for sampling)
+├── otel.yaml                  (RBAC + trace-balancer + gateway; 5-policy tail_sampling, throttled-drop first)
+├── app/
+│   ├── Dockerfile
+│   ├── main.py                (FastAPI + middleware + /admin + OTel SDK + 10% 503 inject)
+│   └── requirements.txt
+├── manifests/
+│   ├── 00-namespace.yaml
+│   ├── 10-postgres.yaml       (StatefulSet + exporter sidecar + PodMonitor)
+│   ├── 20-noisy-app.yaml      (Deployment + Service + PodMonitor)
+│   └── 30-loadgen.yaml        (Deployment scaled 0; ConfigMap with loadgen.py and rates)
+├── scripts/
+│   ├── run-scenario.sh
+│   └── teardown.sh
+└── grafana/
+    └── dashboard.json
+```

--- a/0.9.0/use_cases/noisy_neighbor/app/Dockerfile
+++ b/0.9.0/use_cases/noisy_neighbor/app/Dockerfile
@@ -1,0 +1,7 @@
+FROM python:3.12-slim
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+COPY main.py .
+EXPOSE 8080
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8080", "--log-level", "warning"]

--- a/0.9.0/use_cases/noisy_neighbor/app/main.py
+++ b/0.9.0/use_cases/noisy_neighbor/app/main.py
@@ -1,0 +1,247 @@
+"""
+noisy-app — multi-tenant HTTP service for the MDAI noisy-neighbor lab.
+
+Endpoints
+---------
+- GET  /work?cost=N                runs N small Postgres queries, holding a connection.
+                                   Reads X-Tenant-ID header. Per-tenant asyncpg pool.
+                                   Injects 10% 503 (simulating timeouts/conn failures
+                                   under DB pressure, mostly visible from the noisy tenant
+                                   because it has the most requests).
+- GET  /metrics                    Prometheus scrape endpoint.
+- GET  /healthz                    Liveness.
+- POST /admin/rate-limits          {"tenant":"...","rps":N}  apply or lift throttle.
+- DELETE /admin/rate-limits/{t}    Lift throttle for one tenant.
+
+Tracing
+-------
+Every request creates a span via the OTel FastAPI instrumentation. The /work handler
+adds a `tenant` attribute (matched by the tail sampler) and sets Status.ERROR for
+either an injected 503 or a 429 throttle (with attribute throttled=true).
+
+Span pipeline: app SDK → trace-balancer → gateway (tail_sampling).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import random
+import time
+from contextlib import asynccontextmanager
+
+import asyncpg
+from fastapi import FastAPI, HTTPException, Request, Response
+from fastapi.responses import PlainTextResponse
+from opentelemetry import trace
+from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import OTLPSpanExporter
+from opentelemetry.instrumentation.asyncpg import AsyncPGInstrumentor
+from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor
+from opentelemetry.sdk.resources import Resource
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import BatchSpanProcessor
+from opentelemetry.trace import Status, StatusCode
+from prometheus_client import (
+    CONTENT_TYPE_LATEST,
+    CollectorRegistry,
+    Counter,
+    Gauge,
+    generate_latest,
+)
+from pydantic import BaseModel
+
+PG_DSN = os.environ.get(
+    "PG_DSN", "postgres://app:app@postgres.noisy-neighbor.svc.cluster.local:5432/app"
+)
+POOL_MAX = int(os.environ.get("POOL_MAX_PER_TENANT", "30"))
+POOL_MIN = int(os.environ.get("POOL_MIN_PER_TENANT", "1"))
+ERROR_INJECT_PROB = float(os.environ.get("ERROR_INJECT_PROB", "0.10"))
+OTLP_ENDPOINT = os.environ.get(
+    "OTEL_EXPORTER_OTLP_ENDPOINT", "http://trace-balancer-collector.mdai:4317"
+)
+SERVICE_NAME = os.environ.get("OTEL_SERVICE_NAME", "noisy-app")
+
+resource = Resource.create({"service.name": SERVICE_NAME})
+provider = TracerProvider(resource=resource)
+provider.add_span_processor(
+    BatchSpanProcessor(OTLPSpanExporter(endpoint=OTLP_ENDPOINT, insecure=True))
+)
+trace.set_tracer_provider(provider)
+tracer = trace.get_tracer("noisy-app")
+AsyncPGInstrumentor().instrument()
+
+registry = CollectorRegistry()
+db_conns = Gauge(
+    "db_connections_per_tenant",
+    "Active Postgres connections held by each tenant pool",
+    ["tenant"],
+    registry=registry,
+)
+req_total = Counter(
+    "app_requests_total",
+    "Total app requests",
+    ["tenant", "status"],
+    registry=registry,
+)
+throttled_total = Counter(
+    "app_throttled_total",
+    "Requests rejected by the rate-limiter middleware",
+    ["tenant"],
+    registry=registry,
+)
+errors_total = Counter(
+    "app_errors_total",
+    "Requests that returned 5xx (including injected failures)",
+    ["tenant"],
+    registry=registry,
+)
+
+pools: dict[str, asyncpg.Pool] = {}
+pools_lock = asyncio.Lock()
+rate_limits: dict[str, float] = {}
+buckets: dict[str, tuple[float, float]] = {}
+
+
+async def get_pool(tenant: str) -> asyncpg.Pool:
+    pool = pools.get(tenant)
+    if pool is not None:
+        return pool
+    async with pools_lock:
+        pool = pools.get(tenant)
+        if pool is not None:
+            return pool
+        pool = await asyncpg.create_pool(
+            dsn=PG_DSN,
+            min_size=POOL_MIN,
+            max_size=POOL_MAX,
+            command_timeout=30,
+            server_settings={"application_name": f"noisy-app:{tenant}"},
+        )
+        pools[tenant] = pool
+        return pool
+
+
+async def gauge_refresher():
+    while True:
+        for tenant, pool in list(pools.items()):
+            db_conns.labels(tenant=tenant).set(pool.get_size() - pool.get_idle_size())
+        await asyncio.sleep(1.0)
+
+
+def consume_token(tenant: str) -> bool:
+    rps = rate_limits.get(tenant)
+    if rps is None or rps <= 0:
+        return True
+    now = time.monotonic()
+    tokens, last = buckets.get(tenant, (rps, now))
+    tokens = min(rps, tokens + (now - last) * rps)
+    if tokens >= 1.0:
+        buckets[tenant] = (tokens - 1.0, now)
+        return True
+    buckets[tenant] = (tokens, now)
+    return False
+
+
+@asynccontextmanager
+async def lifespan(_: FastAPI):
+    task = asyncio.create_task(gauge_refresher())
+    try:
+        yield
+    finally:
+        task.cancel()
+        for pool in pools.values():
+            await pool.close()
+
+
+app = FastAPI(lifespan=lifespan)
+FastAPIInstrumentor.instrument_app(app, excluded_urls="/metrics,/healthz")
+
+
+@app.middleware("http")
+async def rate_limit_mw(request: Request, call_next):
+    path = request.url.path
+    if path.startswith("/admin") or path in ("/metrics", "/healthz"):
+        return await call_next(request)
+
+    tenant = request.headers.get("x-tenant-id", "unknown")
+    span = trace.get_current_span()
+    span.set_attribute("tenant", tenant)
+
+    if not consume_token(tenant):
+        throttled_total.labels(tenant=tenant).inc()
+        req_total.labels(tenant=tenant, status="429").inc()
+        span.set_attribute("throttled", True)
+        span.set_attribute("http.response.status_code", 429)
+        span.set_status(Status(StatusCode.ERROR, "rate limited"))
+        return PlainTextResponse("rate limited", status_code=429)
+
+    response = await call_next(request)
+    req_total.labels(tenant=tenant, status=str(response.status_code)).inc()
+    return response
+
+
+@app.get("/healthz")
+async def healthz():
+    return {"ok": True}
+
+
+@app.get("/metrics")
+async def metrics():
+    return Response(generate_latest(registry), media_type=CONTENT_TYPE_LATEST)
+
+
+@app.get("/work")
+async def work(request: Request, cost: int = 3):
+    tenant = request.headers.get("x-tenant-id", "unknown")
+    cost = max(1, min(cost, 20))
+
+    span = trace.get_current_span()
+    span.set_attribute("tenant", tenant)
+    span.set_attribute("work.cost", cost)
+
+    # Inject ~ERROR_INJECT_PROB 5xx — simulates timeouts / conn failures under DB pressure.
+    # Statistically these mostly hit the noisy tenant simply because it has more requests.
+    if random.random() < ERROR_INJECT_PROB:
+        errors_total.labels(tenant=tenant).inc()
+        span.set_attribute("error.injected", True)
+        span.set_status(Status(StatusCode.ERROR, "simulated db timeout"))
+        raise HTTPException(status_code=503, detail="simulated db timeout")
+
+    pool = await get_pool(tenant)
+    try:
+        async with pool.acquire() as conn:
+            async with conn.transaction():
+                for _ in range(cost):
+                    await conn.fetchval("SELECT pg_sleep(0.05)")
+        return {"tenant": tenant, "cost": cost, "ok": True}
+    except Exception as e:
+        errors_total.labels(tenant=tenant).inc()
+        span.set_status(Status(StatusCode.ERROR, str(e)[:120]))
+        raise HTTPException(status_code=503, detail=str(e))
+
+
+class RateLimit(BaseModel):
+    tenant: str
+    rps: float
+
+
+@app.post("/admin/rate-limits", status_code=204)
+async def set_rate_limit(body: RateLimit):
+    if body.rps <= 0:
+        rate_limits.pop(body.tenant, None)
+        buckets.pop(body.tenant, None)
+    else:
+        rate_limits[body.tenant] = body.rps
+    return Response(status_code=204)
+
+
+@app.delete("/admin/rate-limits/{tenant}", status_code=204)
+async def clear_rate_limit(tenant: str):
+    rate_limits.pop(tenant, None)
+    buckets.pop(tenant, None)
+    return Response(status_code=204)
+
+
+@app.get("/admin/rate-limits")
+async def list_rate_limits():
+    return rate_limits

--- a/0.9.0/use_cases/noisy_neighbor/app/requirements.txt
+++ b/0.9.0/use_cases/noisy_neighbor/app/requirements.txt
@@ -1,0 +1,13 @@
+setuptools<81  # pkg_resources removed in setuptools 81 — OTel instrumentation still depends on it
+fastapi==0.115.0
+uvicorn[standard]==0.32.0
+asyncpg==0.30.0
+prometheus-client==0.21.0
+pydantic==2.9.2
+
+# Tracing
+opentelemetry-api==1.27.0
+opentelemetry-sdk==1.27.0
+opentelemetry-exporter-otlp-proto-grpc==1.27.0
+opentelemetry-instrumentation-fastapi==0.48b0
+opentelemetry-instrumentation-asyncpg==0.48b0

--- a/0.9.0/use_cases/noisy_neighbor/grafana/dashboard.json
+++ b/0.9.0/use_cases/noisy_neighbor/grafana/dashboard.json
@@ -1,0 +1,493 @@
+{
+  "annotations": {
+    "list": []
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": null,
+  "title": "MDAI \u00b7 Noisy-Neighbor Lab",
+  "tags": [
+    "mdai",
+    "noisy-neighbor"
+  ],
+  "timezone": "browser",
+  "schemaVersion": 39,
+  "version": 2,
+  "refresh": "10s",
+  "time": {
+    "from": "now-15m",
+    "to": "now"
+  },
+  "templating": {
+    "list": []
+  },
+  "panels": [
+    {
+      "type": "row",
+      "title": "Headline \u2014 closed loop in action",
+      "collapsed": false,
+      "gridPos": {
+        "x": 0,
+        "y": 0,
+        "w": 24,
+        "h": 1
+      }
+    },
+    {
+      "type": "timeseries",
+      "title": "\u2605 Traces KEPT per second by policy \u2014 same noisy tenant, three fates by diagnostic value",
+      "description": "THE headline. Absolute traces/sec each policy KEPT (sampled=true), log scale. This is intentionally NOT a ratio: the tail-sampling metric counts every trace a policy evaluates, so a kept/total ratio dilutes content-matching policies. Absolute kept-volume tells the true story. When the loop fires and NOISY_TENANT_LIST picks up the noisy tenant: noisy-tenant-errors RISES with the error flood (every genuine 5xx kept for diagnosis \u2014 it climbs with intensity, that's the point); noisy-tenant-normal holds at ~50% of their normal volume; noisy-tenant-throttled-drop sits on the floor near zero (their 429s are MDAI's own mitigation working as intended \u2014 no diagnostic value, so we keep ~1% and stop paying to store the rest); healthy-tenant-sample stays low (~2%, untouched). The 429 *rate* is still 100% visible in metrics (Action-1 panel) \u2014 we drop the redundant traces, not the signal. Read the relative heights and the movement, not absolute pixel values.",
+      "gridPos": {
+        "x": 0,
+        "y": 1,
+        "w": 24,
+        "h": 9
+      },
+      "targets": [
+        {
+          "expr": "sum by (policy) (rate(otelcol_processor_tail_sampling_count_traces_sampled_total{sampled=\"true\"}[1m]))",
+          "legendFormat": "{{policy}}",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops",
+          "min": 0,
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 2,
+            "fillOpacity": 10,
+            "lineInterpolation": "smooth",
+            "stacking": {
+              "mode": "none"
+            },
+            "scaleDistribution": {
+              "type": "log",
+              "log": 10
+            }
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "noisy-tenant-errors"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "mode": "fixed",
+                  "fixedColor": "green"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "noisy-tenant-normal"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "mode": "fixed",
+                  "fixedColor": "blue"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "noisy-tenant-throttled-drop"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "mode": "fixed",
+                  "fixedColor": "red"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "healthy-tenant-sample"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "mode": "fixed",
+                  "fixedColor": "yellow"
+                }
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "type": "timeseries",
+      "title": "Tail-sampler decisions per policy (KEEP rate, log scale)",
+      "description": "Supporting view: absolute kept-traces/sec per policy (log scale). Shows the volume behind the keep-rate flip above. A low line here for noisy-tenant-throttled-drop means traces are being discarded on purpose, not that nothing is happening \u2014 read it together with the KEEP-rate panel. Headline panel. When the noisy_neighbor_firing rule fires, the env vars NOISY_TENANT_LIST / HEALTHY_TENANT_LIST swap members and within ~60s the per-policy keep-rates flip: noisy-tenant-errors and noisy-tenant-normal climb; healthy-tenant-sample shrinks. Baseline shows only default-sample matching.",
+      "gridPos": {
+        "x": 0,
+        "y": 10,
+        "w": 24,
+        "h": 9
+      },
+      "targets": [
+        {
+          "expr": "sum by (policy) (rate(otelcol_processor_tail_sampling_count_traces_sampled_total{sampled=\"true\"}[1m]))",
+          "legendFormat": "{{policy}}",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops",
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 2,
+            "fillOpacity": 0,
+            "stacking": {
+              "mode": "none"
+            },
+            "scaleDistribution": {
+              "type": "log",
+              "log": 10
+            }
+          }
+        }
+      }
+    },
+    {
+      "type": "stat",
+      "title": "Firing alerts",
+      "gridPos": {
+        "x": 0,
+        "y": 19,
+        "w": 8,
+        "h": 4
+      },
+      "targets": [
+        {
+          "expr": "ALERTS{alertstate=\"firing\"}",
+          "legendFormat": "{{alertname}} \u00b7 {{tenant}}",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "type": "stat",
+      "title": "Throttle in effect (RPS cap)",
+      "gridPos": {
+        "x": 8,
+        "y": 19,
+        "w": 8,
+        "h": 4
+      },
+      "targets": [
+        {
+          "expr": "max(app_throttled_total) > bool 0",
+          "legendFormat": "throttle active",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        }
+      }
+    },
+    {
+      "type": "stat",
+      "title": "Total spans evaluated by sampler",
+      "gridPos": {
+        "x": 16,
+        "y": 19,
+        "w": 8,
+        "h": 4
+      },
+      "targets": [
+        {
+          "expr": "sum(rate(otelcol_processor_tail_sampling_count_traces_sampled_total[1m]))",
+          "legendFormat": "decisions/s",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops"
+        }
+      }
+    },
+    {
+      "type": "row",
+      "title": "Detection \u2014 what triggered the loop",
+      "collapsed": false,
+      "gridPos": {
+        "x": 0,
+        "y": 23,
+        "w": 24,
+        "h": 1
+      }
+    },
+    {
+      "type": "timeseries",
+      "title": "Postgres connections by tenant (app-emitted)",
+      "gridPos": {
+        "x": 0,
+        "y": 24,
+        "w": 12,
+        "h": 8
+      },
+      "targets": [
+        {
+          "expr": "db_connections_per_tenant",
+          "legendFormat": "{{tenant}}",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        }
+      }
+    },
+    {
+      "type": "timeseries",
+      "title": "Total connections vs max_connections",
+      "gridPos": {
+        "x": 12,
+        "y": 24,
+        "w": 12,
+        "h": 8
+      },
+      "targets": [
+        {
+          "expr": "sum(pg_stat_activity_count)",
+          "legendFormat": "total active",
+          "refId": "A"
+        },
+        {
+          "expr": "max(pg_settings_max_connections)",
+          "legendFormat": "max_connections",
+          "refId": "B"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        }
+      }
+    },
+    {
+      "type": "timeseries",
+      "title": "DB error rate by tenant (5xx = simulated DB failures, pressure proxy)",
+      "gridPos": {
+        "x": 0,
+        "y": 32,
+        "w": 12,
+        "h": 8
+      },
+      "targets": [
+        {
+          "expr": "sum by (tenant) (rate(app_errors_total[1m]))",
+          "legendFormat": "{{tenant}}",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops",
+          "min": 0,
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 2,
+            "fillOpacity": 10
+          }
+        }
+      }
+    },
+    {
+      "type": "timeseries",
+      "title": "Dominance ratio (max-tenant / total, > 0.5 \u2192 noisy_neighbor fires)",
+      "gridPos": {
+        "x": 12,
+        "y": 32,
+        "w": 12,
+        "h": 8
+      },
+      "targets": [
+        {
+          "expr": "max by (tenant) (db_connections_per_tenant) / on() group_left() clamp_min(sum(db_connections_per_tenant), 1)",
+          "legendFormat": "{{tenant}}",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "min": 0,
+          "max": 1,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 0.4
+              },
+              {
+                "color": "red",
+                "value": 0.5
+              }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "type": "row",
+      "title": "Action 1 \u2014 Hard corrective (in-app throttle)",
+      "collapsed": false,
+      "gridPos": {
+        "x": 0,
+        "y": 40,
+        "w": 24,
+        "h": 1
+      }
+    },
+    {
+      "type": "timeseries",
+      "title": "Request status by tenant",
+      "gridPos": {
+        "x": 0,
+        "y": 41,
+        "w": 12,
+        "h": 8
+      },
+      "targets": [
+        {
+          "expr": "sum by (tenant, status) (rate(app_requests_total[1m]))",
+          "legendFormat": "{{tenant}} \u00b7 {{status}}",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps"
+        }
+      }
+    },
+    {
+      "type": "timeseries",
+      "title": "Throttled (429) per second by tenant",
+      "gridPos": {
+        "x": 12,
+        "y": 41,
+        "w": 12,
+        "h": 8
+      },
+      "targets": [
+        {
+          "expr": "sum by (tenant) (rate(app_throttled_total[1m]))",
+          "legendFormat": "{{tenant}}",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps"
+        }
+      }
+    },
+    {
+      "type": "row",
+      "title": "Action 2 \u2014 Diagnostic tail-sampling shift",
+      "collapsed": false,
+      "gridPos": {
+        "x": 0,
+        "y": 49,
+        "w": 24,
+        "h": 1
+      }
+    },
+    {
+      "type": "timeseries",
+      "title": "Sampler decisions: kept vs dropped per policy",
+      "gridPos": {
+        "x": 0,
+        "y": 50,
+        "w": 12,
+        "h": 8
+      },
+      "targets": [
+        {
+          "expr": "sum by (policy, sampled) (rate(otelcol_processor_tail_sampling_count_traces_sampled_total[1m]))",
+          "legendFormat": "{{policy}} \u00b7 sampled={{sampled}}",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops"
+        }
+      }
+    },
+    {
+      "type": "timeseries",
+      "title": "Per-tenant span volume reaching the trace-balancer",
+      "gridPos": {
+        "x": 12,
+        "y": 50,
+        "w": 12,
+        "h": 8
+      },
+      "targets": [
+        {
+          "expr": "sum by (tenant) (rate(trace_span_tenant_total[1m]))",
+          "legendFormat": "{{tenant}}",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops"
+        }
+      }
+    }
+  ]
+}

--- a/0.9.0/use_cases/noisy_neighbor/hub.yaml
+++ b/0.9.0/use_cases/noisy_neighbor/hub.yaml
@@ -1,0 +1,166 @@
+apiVersion: hub.mydecisive.ai/v1
+kind: MdaiHub
+metadata:
+  name: mdaihub-noisy-neighbor
+  namespace: mdai
+  labels:
+    app.kubernetes.io/name: mdai-operator
+    app.kubernetes.io/managed-by: kustomize
+spec:
+  config:
+    evaluation_interval: 15s
+
+  variables:
+    # Map of tenant -> rps_limit, used by the in-app middleware (set via callWebhook).
+    - key: rate_limited_tenants
+      dataType: map
+      storageType: mdai-valkey
+      type: manual
+      serializeAs:
+        - name: RATE_LIMITED_TENANTS_JSON
+
+    # Scalar pressure flag; useful for dashboards / debugging.
+    - key: db_under_pressure
+      dataType: boolean
+      storageType: mdai-valkey
+      type: manual
+      serializeAs:
+        - name: DB_UNDER_PRESSURE
+
+    # Tenants currently flagged as noisy. Drives the tail sampler's high-fidelity policies.
+    - key: noisy_tenant_list
+      dataType: set
+      storageType: mdai-valkey
+      type: manual
+      serializeAs:
+        - name: NOISY_TENANT_LIST
+          transformers:
+            - type: join
+              join:
+                delimiter: "|"
+
+    # Tenants currently considered healthy. Pre-populated at scenario start via SADD.
+    # Drives the tail sampler's budget-preserving policy.
+    - key: healthy_tenant_list
+      dataType: set
+      storageType: mdai-valkey
+      type: manual
+      serializeAs:
+        - name: HEALTHY_TENANT_LIST
+          transformers:
+            - type: join
+              join:
+                delimiter: "|"
+
+  prometheusAlerts:
+    # Pressure signal. In this lab the workload is connection-bound (each /work
+    # request holds a pooled Postgres connection across pg_sleep calls), so the
+    # connection-saturation leg is what actually fires. The cache-hit leg is kept
+    # as a generic template but won't move here — the app does no buffer-read I/O.
+    # The "DB failure" story on the dashboard is carried by injected 5xx errors.
+    - name: db_pressure
+      severity: warning
+      for: 30s
+      keep_firing_for: 90s
+      expr: |
+        (
+          sum(pg_stat_database_blks_hit) /
+          clamp_min(sum(pg_stat_database_blks_hit) + sum(pg_stat_database_blks_read), 1)
+          < 0.7
+        )
+        or
+        (
+          sum(pg_stat_activity_count) /
+          on() group_left() max(pg_settings_max_connections)
+          > 0.2
+        )
+
+    # Dominance: one tenant holds >50% of *active* per-tenant connections AND db is under pressure.
+    - name: noisy_neighbor_detected
+      severity: critical
+      for: 30s
+      keep_firing_for: 90s
+      expr: |
+        (
+          max by (tenant) (db_connections_per_tenant)
+          /
+          on() group_left() clamp_min(sum(db_connections_per_tenant), 1)
+          > 0.5
+        )
+        and on()
+        (
+          ALERTS{alertname="db_pressure",alertstate="firing"} == 1
+        )
+
+  rules:
+    - name: noisy_neighbor_firing
+      when:
+        alertName: noisy_neighbor_detected
+        status: firing
+      then:
+        # 1. Hard corrective: cap the noisy tenant at the app middleware (sub-second propagation).
+        - addToMap:
+            map: rate_limited_tenants
+            key: ${trigger:payload.labels.tenant}
+            value: "5"
+        - callWebhook:
+            url:
+              value: http://noisy-app.noisy-neighbor.svc.cluster.local:8080/admin/rate-limits
+            method: POST
+            templateRef: jsonTemplate
+            payloadTemplate:
+              value: '{"tenant":"${trigger:payload.labels.tenant}","rps":${template:rps}}'
+            templateValues:
+              rps: "5"
+        # 2. Diagnostic tuning: move the tenant from healthy → noisy set.
+        # The tail sampler reads these sets via env vars (~60s ConfigMap refresh lag),
+        # bumping noisy-tenant sampling up and healthy-tenant sampling down.
+        - addToSet:
+            set: noisy_tenant_list
+            value: ${trigger:payload.labels.tenant}
+        - removeFromSet:
+            set: healthy_tenant_list
+            value: ${trigger:payload.labels.tenant}
+
+    - name: noisy_neighbor_resolved
+      when:
+        alertName: noisy_neighbor_detected
+        status: resolved
+      then:
+        # Symmetric inverse — lift the limit, return tenant to the healthy set.
+        - removeFromMap:
+            map: rate_limited_tenants
+            key: ${trigger:payload.labels.tenant}
+        - callWebhook:
+            url:
+              value: http://noisy-app.noisy-neighbor.svc.cluster.local:8080/admin/rate-limits
+            method: POST
+            templateRef: jsonTemplate
+            payloadTemplate:
+              value: '{"tenant":"${trigger:payload.labels.tenant}","rps":${template:rps}}'
+            templateValues:
+              rps: "0"
+        - removeFromSet:
+            set: noisy_tenant_list
+            value: ${trigger:payload.labels.tenant}
+        - addToSet:
+            set: healthy_tenant_list
+            value: ${trigger:payload.labels.tenant}
+
+    - name: db_pressure_firing
+      when:
+        alertName: db_pressure
+        status: firing
+      then:
+        - setVariable:
+            scalar: db_under_pressure
+            value: "true"
+
+    - name: db_pressure_resolved
+      when:
+        alertName: db_pressure
+        status: resolved
+      then:
+        - setVariable:
+            scalar: db_under_pressure
+            value: "false"

--- a/0.9.0/use_cases/noisy_neighbor/manifests/00-namespace.yaml
+++ b/0.9.0/use_cases/noisy_neighbor/manifests/00-namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: noisy-neighbor
+  labels:
+    mydecisive.ai/lab: noisy-neighbor

--- a/0.9.0/use_cases/noisy_neighbor/manifests/10-postgres.yaml
+++ b/0.9.0/use_cases/noisy_neighbor/manifests/10-postgres.yaml
@@ -1,0 +1,135 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: postgres-creds
+  namespace: noisy-neighbor
+type: Opaque
+stringData:
+  POSTGRES_USER: app
+  POSTGRES_PASSWORD: app
+  POSTGRES_DB: app
+  DATA_SOURCE_NAME: postgresql://app:app@localhost:5432/app?sslmode=disable
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: postgres-config
+  namespace: noisy-neighbor
+data:
+  postgresql.conf: |
+    listen_addresses = '*'
+    max_connections = 100
+    shared_buffers = 64MB
+    work_mem = 1MB
+    effective_cache_size = 128MB
+    log_min_duration_statement = 1000
+  init.sql: |
+    CREATE TABLE IF NOT EXISTS items (id serial primary key, payload text);
+    INSERT INTO items (payload) SELECT md5(g::text) FROM generate_series(1, 1000) g
+      ON CONFLICT DO NOTHING;
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: postgres
+  namespace: noisy-neighbor
+spec:
+  serviceName: postgres
+  replicas: 1
+  selector:
+    matchLabels:
+      app: postgres
+  template:
+    metadata:
+      labels:
+        app: postgres
+    spec:
+      containers:
+        - name: postgres
+          image: postgres:16-alpine
+          ports:
+            - containerPort: 5432
+              name: pg
+          envFrom:
+            - secretRef:
+                name: postgres-creds
+          args:
+            - -c
+            - config_file=/etc/postgres/postgresql.conf
+          volumeMounts:
+            - name: pgconf
+              mountPath: /etc/postgres
+            - name: pginit
+              mountPath: /docker-entrypoint-initdb.d
+          readinessProbe:
+            exec:
+              command: ["pg_isready", "-U", "app"]
+            initialDelaySeconds: 5
+            periodSeconds: 5
+          resources:
+            requests: {cpu: "100m", memory: "128Mi"}
+            limits: {cpu: "500m", memory: "256Mi"}
+
+        - name: exporter
+          image: quay.io/prometheuscommunity/postgres-exporter:v0.15.0
+          ports:
+            - containerPort: 9187
+              name: metrics
+          env:
+            - name: DATA_SOURCE_NAME
+              valueFrom:
+                secretKeyRef:
+                  name: postgres-creds
+                  key: DATA_SOURCE_NAME
+          resources:
+            requests: {cpu: "20m", memory: "32Mi"}
+            limits: {cpu: "100m", memory: "64Mi"}
+
+      volumes:
+        - name: pgconf
+          configMap:
+            name: postgres-config
+            items:
+              - key: postgresql.conf
+                path: postgresql.conf
+        - name: pginit
+          configMap:
+            name: postgres-config
+            items:
+              - key: init.sql
+                path: init.sql
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: postgres
+  namespace: noisy-neighbor
+  labels:
+    app: postgres
+spec:
+  selector:
+    app: postgres
+  ports:
+    - name: pg
+      port: 5432
+      targetPort: 5432
+    - name: metrics
+      port: 9187
+      targetPort: 9187
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: postgres-exporter
+  namespace: mdai
+  labels:
+    release: mdai
+spec:
+  namespaceSelector:
+    matchNames: [noisy-neighbor]
+  selector:
+    matchLabels:
+      app: postgres
+  podMetricsEndpoints:
+    - port: metrics
+      interval: 15s

--- a/0.9.0/use_cases/noisy_neighbor/manifests/20-noisy-app.yaml
+++ b/0.9.0/use_cases/noisy_neighbor/manifests/20-noisy-app.yaml
@@ -1,0 +1,75 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: noisy-app
+  namespace: noisy-neighbor
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: noisy-app
+  template:
+    metadata:
+      labels:
+        app: noisy-app
+    spec:
+      containers:
+        - name: app
+          image: noisy-app:0.2.0
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 8080
+              name: http
+          env:
+            - name: PG_DSN
+              value: postgres://app:app@postgres.noisy-neighbor.svc.cluster.local:5432/app
+            - name: POOL_MAX_PER_TENANT
+              value: "30"
+            - name: ERROR_INJECT_PROB
+              value: "0.10"
+            - name: OTEL_SERVICE_NAME
+              value: noisy-app
+            - name: OTEL_EXPORTER_OTLP_ENDPOINT
+              value: http://trace-balancer-collector.mdai.svc.cluster.local:4317
+            - name: OTEL_RESOURCE_ATTRIBUTES
+              value: service.namespace=noisy-neighbor
+          readinessProbe:
+            httpGet: {path: /healthz, port: 8080}
+            initialDelaySeconds: 2
+            periodSeconds: 5
+          resources:
+            requests: {cpu: "100m", memory: "128Mi"}
+            limits: {cpu: "500m", memory: "256Mi"}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: noisy-app
+  namespace: noisy-neighbor
+  labels:
+    app: noisy-app
+spec:
+  selector:
+    app: noisy-app
+  ports:
+    - name: http
+      port: 8080
+      targetPort: 8080
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: noisy-app
+  namespace: mdai
+  labels:
+    release: mdai
+spec:
+  namespaceSelector:
+    matchNames: [noisy-neighbor]
+  selector:
+    matchLabels:
+      app: noisy-app
+  podMetricsEndpoints:
+    - port: http
+      path: /metrics
+      interval: 10s

--- a/0.9.0/use_cases/noisy_neighbor/manifests/30-loadgen.yaml
+++ b/0.9.0/use_cases/noisy_neighbor/manifests/30-loadgen.yaml
@@ -1,0 +1,111 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: loadgen-config
+  namespace: noisy-neighbor
+data:
+  config.json: |
+    {
+      "target": "http://noisy-app.noisy-neighbor.svc.cluster.local:8080/work?cost=4",
+      "tenants": {
+        "tenant-a": 5,
+        "tenant-b": 5,
+        "tenant-c": 5,
+        "noisy-1":  50
+      }
+    }
+  loadgen.py: |
+    """Fire-and-forget loadgen: each tenant has a scheduler coroutine that spawns
+    request tasks at the target rps WITHOUT awaiting their completion, so a slow
+    backend cannot throttle the offered load. A pure rate-limit (open-loop)
+    generator, which is what you want for a noisy-neighbor scenario."""
+    import asyncio, json, time
+    from collections import Counter
+    import httpx
+
+    stats: dict[str, Counter] = {}
+    inflight: dict[str, int] = {}
+
+    async def fire(client, target, tenant, sem):
+        async with sem:
+            inflight[tenant] = inflight.get(tenant, 0) + 1
+            try:
+                r = await client.get(target, headers={"X-Tenant-ID": tenant}, timeout=15.0)
+                code = r.status_code
+            except Exception:
+                code = -2
+            finally:
+                inflight[tenant] -= 1
+            stats[tenant][code] += 1
+
+    async def scheduler(client, target, tenant, rps, sem):
+        interval = 1.0 / max(rps, 1)
+        next_t = time.monotonic()
+        while True:
+            asyncio.create_task(fire(client, target, tenant, sem))
+            next_t += interval
+            dt = next_t - time.monotonic()
+            if dt > 0:
+                await asyncio.sleep(dt)
+            else:
+                next_t = time.monotonic()
+
+    async def reporter():
+        while True:
+            await asyncio.sleep(5)
+            parts = []
+            for t, c in sorted(stats.items()):
+                ok  = c.get(200, 0)
+                lim = c.get(429, 0)
+                five = sum(v for k,v in c.items() if isinstance(k, int) and 500 <= k < 600)
+                net = c.get(-2, 0)
+                parts.append(f"{t}: ok={ok} 429={lim} 5xx={five} net_err={net} inflight={inflight.get(t,0)}")
+            print(" | ".join(parts), flush=True)
+
+    async def main():
+        cfg = json.load(open("/cfg/config.json"))
+        target = cfg["target"]; tenants = cfg["tenants"]
+        for t in tenants: stats[t] = Counter()
+        print(f"loadgen starting: target={target} tenants={tenants}", flush=True)
+        # Per-tenant concurrency cap so an unresponsive backend doesn't OOM us.
+        sem = asyncio.Semaphore(500)
+        async with httpx.AsyncClient(http2=False, limits=httpx.Limits(max_connections=400, max_keepalive_connections=200)) as client:
+            tasks = [asyncio.create_task(scheduler(client, target, t, r, sem)) for t, r in tenants.items()]
+            tasks.append(asyncio.create_task(reporter()))
+            await asyncio.gather(*tasks)
+
+    asyncio.run(main())
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: loadgen
+  namespace: noisy-neighbor
+spec:
+  replicas: 0   # start at 0; scale up when ready to run the scenario
+  selector:
+    matchLabels:
+      app: loadgen
+  template:
+    metadata:
+      labels:
+        app: loadgen
+    spec:
+      containers:
+        - name: loadgen
+          image: python:3.12-slim
+          command: ["/bin/sh", "-c"]
+          args:
+            - |
+              pip install --quiet httpx==0.27.2 && \
+              python /cfg/loadgen.py
+          volumeMounts:
+            - name: cfg
+              mountPath: /cfg
+          resources:
+            requests: {cpu: "50m", memory: "64Mi"}
+            limits: {cpu: "300m", memory: "256Mi"}
+      volumes:
+        - name: cfg
+          configMap:
+            name: loadgen-config

--- a/0.9.0/use_cases/noisy_neighbor/otel.yaml
+++ b/0.9.0/use_cases/noisy_neighbor/otel.yaml
@@ -1,0 +1,294 @@
+# Two-collector trace pipeline.
+#
+#   noisy-app (OTel SDK) ─OTLP→  trace-balancer  ─loadbalanced-by-traceID→  gateway
+#                                                                            │
+#                                                                            ├ tail_sampling
+#                                                                            ├ batch
+#                                                                            └ exporters
+#
+# The gateway's tail_sampling processor reads NOISY_TENANT_LIST and HEALTHY_TENANT_LIST
+# from the configmap that the mdai-operator materializes from the MdaiHub CR's set
+# variables. When the noisy_neighbor_firing rule fires, those sets swap members and
+# the next ConfigMap refresh (~60s) causes the sampler to flip its policies.
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: loadbalancer
+  namespace: mdai
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: loadbalancer-endpointslices-reader
+  namespace: mdai
+rules:
+  - apiGroups: [discovery.k8s.io]
+    resources: [endpointslices]
+    verbs: [get, list, watch]
+  - apiGroups: [""]
+    resources: [endpoints]
+    verbs: [get, list, watch]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: loadbalancer-rolebinding
+  namespace: mdai
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: loadbalancer-endpointslices-reader
+subjects:
+  - kind: ServiceAccount
+    name: loadbalancer
+    namespace: mdai
+---
+apiVersion: opentelemetry.io/v1beta1
+kind: OpenTelemetryCollector
+metadata:
+  name: trace-balancer
+  namespace: mdai
+  labels:
+    mydecisive.ai/hub-name: mdaihub-noisy-neighbor
+spec:
+  serviceAccount: loadbalancer
+  image: otel/opentelemetry-collector-contrib:0.127.0
+  replicas: 1
+  resources:
+    limits: {memory: "256Mi", cpu: "200m"}
+    requests: {memory: "128Mi", cpu: "100m"}
+  config:
+    receivers:
+      otlp/from_agent:
+        protocols:
+          grpc: {endpoint: "0.0.0.0:4317"}
+          http: {endpoint: "0.0.0.0:4318"}
+
+    extensions:
+      health_check:
+        endpoint: "0.0.0.0:13133"
+
+    processors:
+      memory_limiter:
+        limit_mib: 200
+        spike_limit_mib: 50
+        check_interval: 1s
+      batch:
+        send_batch_size: 200
+        send_batch_max_size: 1000
+        timeout: 5s
+      deltatocumulative: {}
+
+    exporters:
+      loadbalancing:
+        routing_key: traceID
+        protocol:
+          otlp:
+            compression: gzip
+            tls: {insecure: true}
+        resolver:
+          k8s:
+            service: gateway-collector-headless.mdai
+
+      prometheus:
+        endpoint: "0.0.0.0:8899"
+        metric_expiration: 180m
+        resource_to_telemetry_conversion: {enabled: true}
+
+    connectors:
+      count/service:
+        spans:
+          trace.span.tenant.total:
+            description: Total span count by tenant attribute.
+            attributes:
+              - key: tenant
+          trace.span.service.root:
+            description: Root span count by service.
+            conditions:
+              - 'IsRootSpan()'
+
+    service:
+      telemetry:
+        resource:
+          mdai-logstream: collector
+        metrics:
+          readers:
+            - pull:
+                exporter:
+                  prometheus: {host: "0.0.0.0", port: 8888}
+      extensions: [health_check]
+      pipelines:
+        traces:
+          receivers: [otlp/from_agent]
+          processors: [memory_limiter, batch]
+          exporters: [loadbalancing, count/service]
+        metrics:
+          receivers: [count/service]
+          processors: [deltatocumulative]
+          exporters: [prometheus]
+
+---
+apiVersion: opentelemetry.io/v1beta1
+kind: OpenTelemetryCollector
+metadata:
+  name: gateway
+  namespace: mdai
+  labels:
+    mydecisive.ai/hub-name: mdaihub-noisy-neighbor
+spec:
+  managementState: managed
+  image: otel/opentelemetry-collector-contrib:0.127.0
+  replicas: 1
+  resources:
+    limits: {memory: "512Mi", cpu: "300m"}
+    requests: {memory: "256Mi", cpu: "100m"}
+  envFrom:
+    - configMapRef:
+        name: mdaihub-noisy-neighbor-variables
+        optional: true
+  config:
+    receivers:
+      otlp/from_lb:
+        protocols:
+          grpc: {endpoint: "0.0.0.0:4317"}
+
+    extensions:
+      health_check:
+        endpoint: "${env:MY_POD_IP}:13133"
+
+    processors:
+      memory_limiter:
+        limit_mib: 420
+        spike_limit_mib: 80
+        check_interval: 1s
+
+      # The whole point of this lab. Four policies, evaluated in order; first match wins.
+      tail_sampling:
+        decision_wait: 10s
+        policies:
+          # 0. THROTTLE-DROP. A noisy-tenant span that was rejected by our own
+          #    rate-limiter (throttled==true). These 429s are MDAI's mitigation
+          #    working as intended — no diagnostic value — so we keep ~1% as a
+          #    sanity sample and drop the other 99%. This policy is FIRST so it
+          #    wins over noisy-tenant-normal (which would otherwise keep 50% of
+          #    them). The 429 *rate* is still fully visible in metrics
+          #    (app_throttled_total / the Action-1 panel); we just stop paying
+          #    to store the redundant per-request traces.
+          - name: noisy-tenant-throttled-drop
+            type: and
+            and:
+              and_sub_policy:
+                - name: is-noisy-tenant
+                  type: string_attribute
+                  string_attribute:
+                    values:
+                      - ${env:NOISY_TENANT_LIST:-a^}
+                    key: tenant
+                    enabled_regex_matching: true
+                - name: is-throttled
+                  type: ottl_condition
+                  ottl_condition:
+                    error_mode: ignore
+                    span:
+                      - 'attributes["throttled"] == true'
+                - name: keep-1-percent
+                  type: probabilistic
+                  probabilistic:
+                    sampling_percentage: 1
+
+          # 1. KEEP EVERYTHING from a noisy tenant that hit a *genuine* DB error (5xx).
+          #    Deliberately does NOT match 429s — those were handled by policy 0
+          #    above. We match the injected-error attribute our /work handler sets,
+          #    OR a Status.ERROR that is not a throttle.
+          - name: noisy-tenant-errors
+            type: and
+            and:
+              and_sub_policy:
+                - name: is-noisy-tenant
+                  type: string_attribute
+                  string_attribute:
+                    key: tenant
+                    # When NOISY_TENANT_LIST is unset/empty, expand to "a^" — a regex
+                    # that matches no string. Without this, the empty regex matches
+                    # everything and inverts the policy semantics.
+                    values:
+                      - ${env:NOISY_TENANT_LIST:-a^}
+                    enabled_regex_matching: true
+                # Genuine DB failures only. We match the injected-error attribute our
+                # /work handler sets, OR a Status.ERROR that is NOT a throttle (the
+                # second clause excludes 429 spans, which carry throttled==true).
+                - name: is-genuine-error
+                  type: ottl_condition
+                  ottl_condition:
+                    error_mode: ignore
+                    span:
+                      - 'attributes["error.injected"] == true'
+                      - 'status.code == STATUS_CODE_ERROR and attributes["throttled"] != true'
+
+          # 2. Sample 50% of the noisy tenant's non-error traffic (still want context).
+          - name: noisy-tenant-normal
+            type: and
+            and:
+              and_sub_policy:
+                - name: is-noisy-tenant
+                  type: string_attribute
+                  string_attribute:
+                    key: tenant
+                    # When NOISY_TENANT_LIST is unset/empty, expand to "a^" — a regex
+                    # that matches no string. Without this, the empty regex matches
+                    # everything and inverts the policy semantics.
+                    values:
+                      - ${env:NOISY_TENANT_LIST:-a^}
+                    enabled_regex_matching: true
+                - name: probabilistic
+                  type: probabilistic
+                  probabilistic:
+                    sampling_percentage: 50
+
+          # 3. Healthy tenants ride 2%. They were fine before, they're fine now — save the budget.
+          - name: healthy-tenant-sample
+            type: and
+            and:
+              and_sub_policy:
+                - name: is-healthy-tenant
+                  type: string_attribute
+                  string_attribute:
+                    key: tenant
+                    values:
+                      - ${env:HEALTHY_TENANT_LIST:-a^}
+                    enabled_regex_matching: true
+                - name: probabilistic
+                  type: probabilistic
+                  probabilistic:
+                    sampling_percentage: 2
+
+          # 4. Default catch-all for spans without a tenant attribute (e.g., infra).
+          - name: default-sample
+            type: probabilistic
+            probabilistic:
+              sampling_percentage: 10
+
+      batch:
+        send_batch_size: 50
+        send_batch_max_size: 200
+        timeout: 10s
+
+    exporters:
+      debug/to_vendor: {}
+
+    service:
+      telemetry:
+        resource:
+          mdai-logstream: collector
+        metrics:
+          readers:
+            - pull:
+                exporter:
+                  prometheus: {host: "0.0.0.0", port: 8888}
+      extensions: [health_check]
+      pipelines:
+        traces:
+          receivers: [otlp/from_lb]
+          processors: [memory_limiter, tail_sampling, batch]
+          exporters: [debug/to_vendor]

--- a/0.9.0/use_cases/noisy_neighbor/scripts/run-scenario.sh
+++ b/0.9.0/use_cases/noisy_neighbor/scripts/run-scenario.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# End-to-end scenario driver for the noisy-neighbor lab.
+#
+# What this script does, in order:
+#   1. Apply namespace, Postgres+exporter, noisy-app, loadgen (scaled to 0).
+#   2. Apply the MdaiHub CR (variables/alerts/rules) and the OTel collectors
+#      (trace-balancer + gateway with tail_sampling).
+#   3. Wait for everything healthy.
+#   4. Pre-populate healthy_tenant_list in Valkey with our four tenants.
+#      (Idempotent: re-running keeps the same set; SADD ignores duplicates.)
+#   5. Scale loadgen to 1 — noisy-neighbor scenario begins.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+NS=noisy-neighbor
+MDAI_NS=mdai
+
+step() { printf "\n▶ %s\n" "$*"; }
+
+step "Apply manifests"
+kubectl apply -f "$ROOT/manifests/00-namespace.yaml"
+kubectl apply -f "$ROOT/manifests/10-postgres.yaml"
+kubectl apply -f "$ROOT/manifests/20-noisy-app.yaml"
+kubectl apply -f "$ROOT/manifests/30-loadgen.yaml"
+
+step "Apply MdaiHub CR (variables, alerts, rules)"
+kubectl apply -f "$ROOT/hub.yaml"
+
+step "Apply OTel collectors (trace-balancer + gateway with tail_sampling)"
+kubectl apply -f "$ROOT/otel.yaml"
+
+step "Wait for Postgres + noisy-app readiness"
+kubectl -n "$NS" rollout status sts/postgres --timeout=180s
+kubectl -n "$NS" rollout status deploy/noisy-app --timeout=180s
+
+step "Wait for collectors"
+kubectl -n "$MDAI_NS" wait --for=condition=Ready pod -l app.kubernetes.io/component=opentelemetry-collector --timeout=120s || true
+
+step "Pre-populate healthy_tenant_list in Valkey"
+# The MdaiHub variable is materialized into a Valkey set under
+#   variable/<hub-name>/<varname>
+# Pre-populating here ensures the tail sampler has a healthy set to match
+# against from the first ConfigMap refresh — no chicken-and-egg.
+# (Idempotent: SADD ignores existing members.)
+VALKEY_KEY="variable/mdaihub-noisy-neighbor/healthy_tenant_list"
+VALKEY_PASS="$(kubectl -n "$MDAI_NS" get secret valkey-secret \
+  -o jsonpath='{.data.VALKEY_PASSWORD}' | base64 -d)"
+kubectl -n "$MDAI_NS" exec mdai-valkey-primary-0 -- env PASS="$VALKEY_PASS" \
+  sh -c 'valkey-cli -a "$PASS" --no-auth-warning SADD '"$VALKEY_KEY"' tenant-a tenant-b tenant-c noisy-1'
+
+step "Force MdaiHub reconcile so the populated set is rendered into the variables ConfigMap"
+kubectl -n "$MDAI_NS" annotate mdaihub mdaihub-noisy-neighbor \
+  reconcile.mydecisive.ai/timestamp="$(date -u +%s)" --overwrite >/dev/null
+
+step "Scale up loadgen — scenario begins"
+kubectl -n "$NS" scale deploy/loadgen --replicas=1
+
+cat <<EOF
+
+Scenario started. Watch the loop in separate terminals:
+
+  # 1. Per-tenant request mix from the load generator
+  kubectl -n $NS logs -f deploy/loadgen
+
+  # 2. Live rate-limit table inside the app
+  kubectl -n $NS port-forward svc/noisy-app 8080:8080 &
+  watch -n 1 'curl -s localhost:8080/admin/rate-limits'
+
+  # 3. Tail-sampler decisions (the diagnostic side of the story)
+  kubectl -n $MDAI_NS port-forward svc/kube-prometheus-stack-prometheus 9090:9090 &
+  open 'http://localhost:9090/graph?g0.expr=sum%20by%20(policy)%20(rate(otelcol_processor_tail_sampling_count_traces_sampled%5B1m%5D))'
+
+  # 4. Prometheus alerts and Grafana
+  open http://localhost:9090/alerts
+  kubectl -n $MDAI_NS port-forward svc/mdai-grafana 3000:80 &
+  # Grafana: admin / mdai
+
+  # 5. Current contents of the two Valkey sets
+  PASS=\$(kubectl -n $MDAI_NS get secret valkey-secret -o jsonpath='{.data.VALKEY_PASSWORD}' | base64 -d)
+  kubectl -n $MDAI_NS exec mdai-valkey-primary-0 -- env P=\$PASS sh -c \\
+    'valkey-cli -a "\$P" --no-auth-warning SMEMBERS variable/mdaihub-noisy-neighbor/noisy_tenant_list'
+  kubectl -n $MDAI_NS exec mdai-valkey-primary-0 -- env P=\$PASS sh -c \\
+    'valkey-cli -a "\$P" --no-auth-warning SMEMBERS variable/mdaihub-noisy-neighbor/healthy_tenant_list'
+EOF

--- a/0.9.0/use_cases/noisy_neighbor/scripts/teardown.sh
+++ b/0.9.0/use_cases/noisy_neighbor/scripts/teardown.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+kubectl delete -f "$ROOT/otel.yaml" --ignore-not-found
+kubectl delete -f "$ROOT/hub.yaml" --ignore-not-found
+kubectl delete -f "$ROOT/manifests/30-loadgen.yaml" --ignore-not-found
+kubectl delete -f "$ROOT/manifests/20-noisy-app.yaml" --ignore-not-found
+kubectl delete -f "$ROOT/manifests/10-postgres.yaml" --ignore-not-found
+kubectl delete -f "$ROOT/manifests/00-namespace.yaml" --ignore-not-found


### PR DESCRIPTION
## Description
NOTICKET: This is a community experiment/contribution

This PR implements real-time discovery and stateful alerting for HTTP 429 status codes, leveraging edge OpenTelemetry configurations to identify "noisy neighbor" services before they impact the Amazon Aurora DB cluster. By shifting the inspection boundary to the edge, this proactive approach enables immediate blast-radius isolation and prevents resource exhaustion in shared database environments. 

Want to see it in action? Watch the 3-minute Loom walkthrough where Salehi spins up the load test, isolates the noisy tenant, and forces the trace drops in real-time.

<video src="https://github.com/user-attachments/assets/e08a16b1-6b33-4499-8541-9a2b9ab0b609
" controls width="100%"></video>


## What type of PR is this? (only check one)

- [X] Feature (`feat`)
- [ ] Bug Fix (`fix`)
- [ ] Refactor (`refactor`)
- [ ] Documentation Update (`doc`)
- [ ] Other, please specify: 

### Does this PR introduce any breaking changes?
- [X] No
- [ ] Yes, and this is why: 
- [ ] I need help determining if there are any breaking changes

### Does the PR title type prefix match the selected type?
- [X] Yes
- [ ] No, and this is why: 
- [ ] I need help select the right one

## Added/updated tests?
_Please keep the code coverage percentage at 80% and above._
- [X] Yes
- [ ] No, and this is why: 
- [ ] I need help with writing tests
